### PR TITLE
Get true/false quoting behavior from the driver

### DIFF
--- a/src/sys/db/Manager.hx
+++ b/src/sys/db/Manager.hx
@@ -556,7 +556,7 @@ class Manager<T : Object> {
 				}
 			}
 		if( first )
-			s.add("TRUE");
+			getCnx().addValue(s, true);
 	}
 
 	/* --------------------------- MISC API  ------------------------------ */
@@ -712,7 +712,7 @@ class Manager<T : Object> {
 				cnx.addValue(b, v);
 			}
 		if( first )
-			return "FALSE";
+			return quoteAny(false);
 		return v + " IN (" + b.toString() + ")";
 	}
 

--- a/src/sys/db/Manager.hx
+++ b/src/sys/db/Manager.hx
@@ -179,7 +179,7 @@ class Manager<T : Object> {
 		}
 		s.add("INSERT INTO ");
 		s.add(table_name);
-		if (fields.length > 0 || cnx.dbName() != "SQLite")
+		if (fields.length > 0 || getCnx().dbName() != "SQLite")
 		{
 			s.add(" (");
 			s.add(fields.join(","));

--- a/src/sys/db/RecordMacros.hx
+++ b/src/sys/db/RecordMacros.hx
@@ -501,8 +501,6 @@ class RecordMacros {
 			case CIdent(n):
 				switch( n ) {
 				case "null": return { expr : EConst(CString("NULL")), pos : v.pos };
-				case "true": return { expr : EConst(CString("TRUE")), pos : v.pos };
-				case "false": return { expr : EConst(CString("FALSE")), pos : v.pos };
 				}
 			default:
 			}
@@ -727,7 +725,7 @@ class RecordMacros {
 				else
 					fields.set(fi.name, true);
 			}
-			if( first ) sqlAddString(sql, "TRUE");
+			if( first ) sqlAdd(sql, sqlQuoteValue({ expr : EConst(CIdent("true")), pos : sql.pos }, DBool, false), sql.pos);
 			sql = sqlAddString(sql, ")");
 			return { sql : sql, t : DBool, n : false };
 		case EParenthesis(e):
@@ -837,10 +835,6 @@ class RecordMacros {
 				switch( n ) {
 				case "null":
 					return { sql : makeString("NULL", p), t : DNull, n : true };
-				case "true":
-					return { sql : makeString("TRUE", p), t : DBool, n : false };
-				case "false":
-					return { sql : makeString("FALSE", p), t : DBool, n : false };
 				}
 				return buildDefault(cond);
 			}


### PR DESCRIPTION
**This is a work in progress**

This fixes a bug on SQLite connections, introduced by HaxeFoundation/haxe#3044:

```
SomeObject.manager.search(true)
```

fails

```
Uncaught exception - Error while executing SELECT * FROM SomeObject WHERE TRUE (Sqlite error in SELECT * FROM SomeObject WHERE TRUE : no such column: TRUE)
```

See also: #2 and [HaxeFoundation/haxe#3691](https://github.com/HaxeFoundation/haxe/issues/3691#issuecomment-89674230)