### PR TITLE
Remove dynamic getters&setters for Neko

### DIFF
--- a/src/sys/db/Manager.hx
+++ b/src/sys/db/Manager.hx
@@ -612,34 +612,7 @@ class Manager<T : Object> {
 		var lock = r.lock;
 		if( manager == null || manager.table_keys == null ) throw ("Invalid manager for relation "+table_name+":"+r.prop);
 		if( manager.table_keys.length != 1 ) throw ("Relation " + r.prop + "(" + r.key + ") on a multiple key table");
-#if neko
-		Reflect.setField(class_proto.prototype,"get_"+r.prop,function() {
-			var othis = untyped __this__;
-			var f = Reflect.field(othis,hprop);
-			if( f != null )
-				return f;
-			var id = Reflect.field(othis, hkey);
-			if( id == null )
-				return null;
-			f = manager.unsafeGet(id,lock);
-			// it's highly possible that in that case the object has been inserted
-			// after we started our transaction : in that case, let's lock it, since
-			// it's still better than returning 'null' while it exists
-			if( f == null && id != null && !lock )
-				f = manager.unsafeGet(id,true);
-			Reflect.setField(othis,hprop,f);
-			return f;
-		});
-		Reflect.setField(class_proto.prototype,"set_"+r.prop,function(f) {
-			var othis = untyped __this__;
-			Reflect.setField(othis,hprop,f);
-			Reflect.setField(othis,hkey,Reflect.field(f,manager.table_keys[0]));
-			return f;
-		});
-#end
 	}
-
-	#if !neko
 
 	function __get( x : Dynamic, prop : String, key : String, lock ) {
 		var v = Reflect.field(x,prop);
@@ -658,8 +631,6 @@ class Manager<T : Object> {
 			Reflect.setField(x,key,Reflect.field(v,table_keys[0]));
 		return v;
 	}
-
-	#end
 
 	/* ---------------------------- OBJECT CACHE -------------------------- */
 

--- a/src/sys/db/RecordMacros.hx
+++ b/src/sys/db/RecordMacros.hx
@@ -1321,9 +1321,7 @@ class RecordMacros {
 					switch( f.kind ) {
 						case FVar(t, _):
 							f.kind = FProp("dynamic", "dynamic", t);
-							if( isNeko )
-								continue;
-							// create compile-time getter/setter for other platforms
+							// create compile-time getter/setter for all platforms
 							var relKey = null;
 							var relParams = [];
 							var lock = false;
@@ -1402,7 +1400,7 @@ class RecordMacros {
 			var inst = Context.getLocalClass().get();
 			if( inst.meta.has(":skip") )
 				return fields;
-			if (!Context.defined('neko'))
+			if (!isNeko)
 			{
 				var iname = { expr:EConst(CIdent(inst.name)), pos: inst.pos };
 				var getM = {

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -851,6 +851,26 @@ class Test
 		other1.delete();
 	}
 
+	/**
+		Check that relations are not affected by the analyzer
+
+		See: #6 and HaxeFoundation/haxe#6048
+
+		The way the analyzer transforms the expression (to prevent potential
+		side-effects) might change the context where `untyped __this__` is
+		evaluated.
+	**/
+	public function testIssue6()
+	{
+		setManager();
+
+		var parent = new MySpodClass();
+		parent.relation = new OtherSpodClass("i");
+
+		f(parent.relation == null);
+		eq(parent.relation.name, "i");
+	}
+
 	private function pos(?p:haxe.PosInfos):haxe.PosInfos
 	{
 		p.fileName = p.fileName + "(" + cnx.dbName()  +")";


### PR DESCRIPTION
Fix #6; fix HaxeFoundation/haxe#6048

On Neko, the getters and setters for relations were only generated at runtime,
and depended on `untyped __this__` being evaluated in the context of the parent
object.

However, the way the analyzer transforms the expression (to prevent potential
side-effects) might change the context where `untyped __this__` is
evaluated after all.

There's no apparent reason (I could find) for keeping this separate
implementation just for Neko.  This PRs simply changes Neko to use the same
compile time generation of properties the other targets use, and adds a small
test case.