### PR TITLE
Get the actual type from a TLazy

### DIFF
--- a/src/sys/db/RecordMacros.hx
+++ b/src/sys/db/RecordMacros.hx
@@ -266,6 +266,8 @@ class RecordMacros {
 				default:
 				}
 			return makeType(follow(t, true));
+		case TLazy(f):
+			return makeType(f());
 		default:
 		}
 		throw "Unsupported Record Type " + Std.string(t);

--- a/test/MySpodClass.hx
+++ b/test/MySpodClass.hx
@@ -107,3 +107,20 @@ abstract AbstractSpodTest<A>(A) from A
 @:keep class Issue6041Table extends Object {
 	public var id:SInt = 0;
 }
+
+// issue #<to be numbered>
+class TLazyIssueFoo extends sys.db.Object {
+	public var id:SId;
+	@:relation(bid) public var bar:TLazyIssueBar;
+
+	public function new(bar:TLazyIssueBar)
+	{
+		var lastFoo = TLazyIssueFoo.manager.select($bar == bar, { orderBy : -id, limit : 1 }, false);
+		super();
+	}
+}
+class TLazyIssueBar extends sys.db.Object {
+	public var id:SId;
+	public var initialized:SString<255> = "bar";
+}
+


### PR DESCRIPTION
We started to get some (unhandled) TLazy types with Haxe 4 in constructs like

```haxe
import sys.db.Types;

class Foo extends sys.db.Object {
	public var id:SId;
	@:relation(bid) public var bar:Bar;

	public function new(bar:Bar)
	{
		var lastFoo = Foo.manager.select($bar == bar, { orderBy : -id, limit : 1 }, false); // required
		super();
	}
}

class Bar extends sys.db.Object {
	public var id:SId;
	public var name:SString<255> = "bar";  // required
}

class Test {
	static function main() {}
}
```

Forcing a concrete type out of the TLazy (what would be a better name for this?) seems to fix the issue and not cause other problems.