### PR TITLE
Match field types by name and sub-type name

### DIFF
--- a/src/sys/db/RecordMacros.hx
+++ b/src/sys/db/RecordMacros.hx
@@ -1258,7 +1258,7 @@ class RecordMacros {
 		case TPType(t): t;
 		};
 		var pos = f.pos;
-		switch( p.name ) {
+		switch( p.sub != null ? p.sub : p.name ) {
 		case "SData":
 			f.kind = FProp("dynamic", "dynamic", rt, null);
 			f.meta.push( { name : ":data", params : [], pos : f.pos } );

--- a/test/MySpodClass.hx
+++ b/test/MySpodClass.hx
@@ -124,3 +124,9 @@ class TLazyIssueBar extends sys.db.Object {
 	public var initialized:SString<255> = "bar";
 }
 
+
+@:keep class Issue19SpodClass extends Object {
+	public var id:SId;
+	public var anEnum:sys.db.Types.SEnum<SpodEnum>;
+}
+

--- a/test/SQLiteTest.hx
+++ b/test/SQLiteTest.hx
@@ -24,6 +24,7 @@ class SQLiteTest
 		try Manager.cnx.request('DROP TABLE ClassWithStringIdRef') catch(e:Dynamic) {}
 		try Manager.cnx.request('DROP TABLE IssueC3828') catch(e:Dynamic) {}
 		try Manager.cnx.request('DROP TABLE Issue6041Table') catch(e:Dynamic) {}
+		try Manager.cnx.request('DROP TABLE Issue19SpodClass') catch(e:Dynamic) {}
 		TableCreate.create(MySpodClass.manager);
 		TableCreate.create(OtherSpodClass.manager);
 		TableCreate.create(NullableSpodClass.manager);
@@ -559,6 +560,13 @@ class SQLiteTest
 
 		Assert.isNotNull(parent.relation);
 		Assert.equals("i", parent.relation.name);
+	}
+
+	public function testIssue19()
+	{
+		var val = new Issue19SpodClass();
+		val.anEnum = SecondValue;
+		val.insert();
 	}
 
 	private function pos(?p:haxe.PosInfos):haxe.PosInfos


### PR DESCRIPTION
Fixes #19, where typing a field as `sys.db.Types.SEnum` would not be correctly handled.