### PR TITLE
fixed: string concatenation did not work with SQLite

### DIFF
--- a/src/sys/db/Manager.hx
+++ b/src/sys/db/Manager.hx
@@ -50,6 +50,7 @@ class Manager<T : Object> {
 	private static function set_cnx( c : Connection ) {
 		cnx = c;
 		lockMode = (c != null && c.dbName() == "MySQL") ? " FOR UPDATE" : "";
+		if( c !=null && cnx.dbName() == "MySQL" ) cnx.request("SET sql_mode = 'PIPES_AS_CONCAT'");
 		return c;
 	}
 

--- a/src/sys/db/RecordMacros.hx
+++ b/src/sys/db/RecordMacros.hx
@@ -740,13 +740,12 @@ class RecordMacros {
 			case OpAdd:
 				var r1 = buildCond(e1);
 				var r2 = buildCond(e2);
-				var rt = if( tryUnify(r1.t, DFloat) && tryUnify(r2.t, DFloat) )
-					tryUnify(r1.t, DInt) ? tryUnify(r2.t, DInt) ? DInt : DFloat : DFloat;
+				if( tryUnify(r1.t, DFloat) && tryUnify(r2.t, DFloat) )
+					return { sql : makeOp("+", r1.sql, r2.sql, p), t : tryUnify(r1.t, DInt) && tryUnify(r2.t, DInt) ? DInt : DFloat, n : r1.n || r2.n };
 				else if( (tryUnify(r1.t, DText) && canStringify(r2.t)) || (tryUnify(r2.t, DText) && canStringify(r1.t)) )
-					return { sql : sqlAddString(sqlAdd(sqlAddString(sqlAdd(makeString("CONCAT(",p),r1.sql,p),","),r2.sql,p),")"), t : DText, n : r1.n || r2.n }
+					return { sql : makeOp("||", r1.sql, r2.sql, p), t : DText, n : r1.n || r2.n };
 				else
 					error("Can't add " + typeStr(r1.t) + " and " + typeStr(r2.t), p);
-				return { sql : makeOp("+", r1.sql, r2.sql, p), t : rt, n : r1.n || r2.n };
 			case OpBoolAnd, OpBoolOr:
 				var r1 = buildCond(e1);
 				var r2 = buildCond(e2);

--- a/test/MySQLTest.hx
+++ b/test/MySQLTest.hx
@@ -580,6 +580,25 @@ class MySQLTest
 		Assert.equals("i", parent.relation.name);
 	}
 
+	@Test
+	public function testStringConcatenation()
+	{
+		var other1 = new OtherSpodClass("required field");
+		other1.insert();
+
+		var c1 = getDefaultClass();
+		c1.string = "testData4";
+		c1.int = 4;
+		c1.relation = other1;
+		c1.insert();
+
+		var q = MySpodClass.manager.select($string == "test"+"Data"+$int);
+		Assert.isNotNull(q);
+
+		c1.delete();
+		other1.delete();
+	}
+
 	private function pos(?p:haxe.PosInfos):haxe.PosInfos
 	{
 		p.fileName = p.fileName + "(" + Manager.cnx.dbName()  +")";

--- a/test/SQLiteTest.hx
+++ b/test/SQLiteTest.hx
@@ -561,6 +561,25 @@ class SQLiteTest
 		Assert.equals("i", parent.relation.name);
 	}
 
+	@Test
+	public function testStringConcatenation()
+	{
+		var other1 = new OtherSpodClass("required field");
+		other1.insert();
+
+		var c1 = getDefaultClass();
+		c1.string = "testData4";
+		c1.int = 4;
+		c1.relation = other1;
+		c1.insert();
+
+		var q = MySpodClass.manager.select($string == "test"+"Data"+$int);
+		Assert.isNotNull(q);
+
+		c1.delete();
+		other1.delete();
+	}
+
 	private function pos(?p:haxe.PosInfos):haxe.PosInfos
 	{
 		p.fileName = p.fileName + "(" + Manager.cnx.dbName()  +")";


### PR DESCRIPTION
fixes #28

record-macros was attempting to use the MySQL `CONCAT` function for string concatenation, which is not supported in SQLite, resulting in sql errors.

This change switches to using the slightly more standard string concat pipe operator (||) which is supported on both platforms. However, in order to use this feature in MySQL the `PIPES_AS_CONCAT` sql_mode must be enabled, thus this is done automatically in `sys.db.Manager.set_cnx` upon MySQL assignment.

This does mean we're altering the sys.db.Connection upon assignment. Alternatively we could just use differing syntax depending on connection type, but I'm not sure the best way of performing this check within RecordMacros, as we're in compiletime land, there.