### PR TITLE
Don't break @:skip fields when resetting cached & unlocked objects

### DIFF
--- a/src/sys/db/Manager.hx
+++ b/src/sys/db/Manager.hx
@@ -670,7 +670,7 @@ class Manager<T : Object> {
 		if( c != null && lock && !c._lock ) {
 			// synchronize the fields since our result is up-to-date !
 			for( f in Reflect.fields(c) )
-				Reflect.deleteField(c,f);
+				Reflect.setField(c,f,null);
 			for (f in table_infos.fields)
 			{
 				var name = f.name,

--- a/test/MySpodClass.hx
+++ b/test/MySpodClass.hx
@@ -58,6 +58,8 @@ import sys.db.Types;
 	public var theid:SInt;
 	public var name:SString<255>;
 
+	@:skip public var ignored:String;
+
 	public function new(name:String)
 	{
 		super();


### PR DESCRIPTION
Unlike in Neko, in PHP a field can no longer be accessed after it has
been removed with Reflect.deleteField.  Use Reflect.setField instead.

Not bothering with clearing the fields of cache items was considered,
but would make the behavior @:skip fields less predictable, besides
potentially breaking user code.

Related: HaxeFoundation/haxe#8016 ("Possible PHP7 haxe.Serializer bug")
Closes: #34 ("Synchronizing the fields")