### PR TITLE
Make tests themself use Date.toString() so it's not DCE-ed

### DIFF
--- a/test/Main.hx
+++ b/test/Main.hx
@@ -4,6 +4,10 @@ import hex.unittest.runner.*;
 class Main {
 	static function main() {
 		var arg = Sys.args()[0];
+        
+        // don't lose Date.toString() to DCE
+        var s = Date.now().toString();
+        var n = s.length;
 		var mysqlConnection = (arg != null && arg.substr(0,8)=="mysql://") ? arg : null;
 
 		var emu = new ExMachinaUnitCore();

--- a/test/Main.hx
+++ b/test/Main.hx
@@ -15,9 +15,9 @@ class Main {
 		emu.addListener(new ExitingNotifier());
 
 		// use addRuntimeTest so the inheritance chain is followed
-		emu.addRuntimeTest(SQLiteTest);
 		if(mysqlConnection != null)
 			emu.addRuntimeTest(MySQLTest);
+		emu.addRuntimeTest(SQLiteTest);
 
 		emu.run();
 	}


### PR DESCRIPTION
If not having this DCE protection in test/Main.hx, when a new hxml is created using not -lib but -cp directly (as needed by lix I think) you get almost all unit tests for mysql fail, because all dates appear as **Date** in the SQL, instead of e.g. "2018-12-03 12:11:03". 

Commit 756ec655befe9dc60800a244b300a7151db25daa tried to address that. Testing on hxcpp and lix however,
the hxml file has to be changed and it's very easy for the
extraParams.hxml fix (appending a macro so Date.toString() does not get
DCE-ed) to not get applied when self testing.

